### PR TITLE
KAT0001-1084: remove duplicate crontab sync shipments

### DIFF
--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -21,9 +21,5 @@
         <job name="shippit_sync_shipments" instance="\Shippit\Shipping\Model\Api\Shipment" method="run">
             <schedule>* * * * *</schedule>
         </job>
-        <job name="shippit_sync_shipments" instance="\Shippit\Shipping\Model\Api\Shipment"
-        method="run">
-            <schedule>* * * * *</schedule>
-        </job>
     </group>
 </config>


### PR DESCRIPTION
Error on running crontabs

php bin/magento cron:run
[Magento\Framework\Exception\LocalizedException]
 Invalid Document
 Element 'job': Duplicate key-sequence ['shippit_sync_shipments'] in unique identity-constraint 'uniqueJobName'.

it caused by duplicate crontab name 'shippit_sync_shipments' at crontab.xml

`        <job name="shippit_sync_shipments" instance="\Shippit\Shipping\Model\Api\Shipment" method="run">
            <schedule>* * * * *</schedule>
        </job>
        <job name="shippit_sync_shipments" instance="\Shippit\Shipping\Model\Api\Shipment"
        method="run">
            <schedule>* * * * *</schedule>
        </job>`