### PR TITLE
Fix checkout error "Uncaught Error: Call to a member function getShippitDeliveryInstructions() on null

### DIFF
--- a/Plugin/Checkout/QuoteDeliveryInstructionsPlugin.php
+++ b/Plugin/Checkout/QuoteDeliveryInstructionsPlugin.php
@@ -55,6 +55,10 @@ class QuoteDeliveryInstructionsPlugin
         }
 
         $extensionAttributes = $addressInformation->getExtensionAttributes();
+        if ($extensionAttributes === null) {
+            return;
+        }
+        
         $deliveryInstructions = $extensionAttributes->getShippitDeliveryInstructions();
 
         $quote = $this->quoteRepository->getActive($cartId);


### PR DESCRIPTION
Fixes the below error when attempting to checkout with a shipping method that isn't Shippit

Magento 2.2.4

```
{"messages":{"error":[{"code":500,"message":"Fatal Error: 'Uncaught Error: Call to a member function getShippitDeliveryInstructions() on null in \/var\/www\/current\/src\/vendor\/shippit\/magento2\/Plugin\/Checkout\/QuoteDeliveryInstructionsPlugin.php:58\nStack trace:\n#0 \/var\/www\/current\/src\/vendor\/magento\/framework\/Interception\/Interceptor.php(121): Shippit\\Shipping\\Plugin\\Checkout\\QuoteDeliveryInstructionsPlugin->beforeSaveAddressInformation(Object(Magento\\Checkout\\Model\\ShippingInformationManagement\\Interceptor), 4428468, Object(Magento\\Checkout\\Model\\ShippingInformation))\n#1 \/var\/www\/current\/src\/vendor\/magento\/framework\/Interception\/Interceptor.php(153): Magento\\Checkout\\Model\\ShippingInformationManagement\\Interceptor->Magento\\Framework\\Interception\\{closure}(4428468, Object(Magento\\Checkout\\Model\\ShippingInformation))\n#2 \/var\/www\/current\/src\/generated\/code\/Magento\/Checkout\/Model\/ShippingInformationManagement\/Interceptor.php(26): Magento\\Checkout\\Model\\ShippingInformationManagement\\Interceptor->___callPlugins('saveAddressInfo...', Array, Array)\n#3 [internal function]: Magen' in '\/var\/www\/current\/src\/vendor\/shippit\/magento2\/Plugin\/Checkout\/QuoteDeliveryInstructionsPlugin.php' on line 58","trace":"Trace is not available."}]}}
```