### PR TITLE
Fix #13 : getAttributeValue doesn't work if `_` or `-` inside the attribute_code

### DIFF
--- a/Helper/Sync/Order/Items.php
+++ b/Helper/Sync/Order/Items.php
@@ -328,6 +328,6 @@ class Items extends \Shippit\Shipping\Helper\Sync\Order
             )
         );
 
-        return $prefix . $functionName;
+        return $prefix . str_replace(' ', '', $functionName);
     }
 }


### PR DESCRIPTION

# Bad generation function name for product

after commit https://github.com/Go-Shippit/Magento2/commit/972f9f27ac3bc36c8a89834867506c994a72d3fb the function `getFunctionName` of Class `Shippit\Shipping\Helper\Sync\Order\Items` don't manage properly the generation of functionName for product

indeed the output of `item_length` gonna be `getItem Length` the space from the result ucword is not removed.

in this PR I remove the space. 