### PR TITLE
Fix/magento 242 compatibility

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -99,7 +99,7 @@ class Order
     public function run()
     {
         if (!$this->_helper->isActive()) {
-            return $this;
+            return;
         }
 
         // get all stores, as we will emulate each storefront for integration run
@@ -127,7 +127,7 @@ class Order
 
     /**
      * Get a list of sync orders pending sync
-     * @return [type] [description]
+     * @return \Shippit\Shipping\Model\ResourceModel\Sync\Order\Collection
      */
     public function getSyncOrders($storeId)
     {
@@ -160,6 +160,11 @@ class Order
             );
     }
 
+    /**
+     * @param SyncOrder $syncOrder
+     * @param bool $displayNotifications
+     * @return bool
+     */
     public function sync($syncOrder, $displayNotifications = false)
     {
         if (!$this->_helper->isActive()) {

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -20,7 +20,7 @@ use Exception;
 use Magento\Framework\App\Area as AppArea;
 use Shippit\Shipping\Model\Sync\Order as SyncOrder;
 
-class Order extends \Magento\Framework\Model\AbstractModel
+class Order
 {
     /**
      * @var \Shippit\Shipping\Helper\Sync\Order
@@ -83,12 +83,7 @@ class Order extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Magento\Store\Model\StoreManagerInterface $storeManagerInterface,
-        \Magento\Store\Model\App\Emulation $appEmulation,
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Registry $registry,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        \Magento\Store\Model\App\Emulation $appEmulation
     ) {
         $this->_helper = $helper;
         $this->_api = $api;
@@ -99,8 +94,6 @@ class Order extends \Magento\Framework\Model\AbstractModel
         $this->_date = $date;
         $this->_storeManagerInterface = $storeManagerInterface;
         $this->_appEmulation = $appEmulation;
-
-        parent::__construct($context, $registry, $resource, $resourceCollection, $data);
     }
 
     public function run()

--- a/Model/Api/Shipment.php
+++ b/Model/Api/Shipment.php
@@ -117,7 +117,7 @@ class Shipment
             );
 
             if (!$this->_helper->isActive()) {
-                return $this;
+                continue;
             }
 
             // get shipments to sync

--- a/Model/Api/Shipment.php
+++ b/Model/Api/Shipment.php
@@ -134,7 +134,7 @@ class Shipment
 
     /**
      * Get a list of sync orders pending sync
-     * @return [type] [description]
+     * @return \Shippit\Shipping\Model\ResourceModel\Sync\Shipment\Collection
      */
     public function getSyncShipments($storeId)
     {
@@ -156,9 +156,9 @@ class Shipment
 
     /**
      * Process each shipment queue record to create shipment record
-     * @param  shipment  $syncShipment
-     * @param  boolean $displayNotifications
-     * @return Shipment
+     * @param  SyncShipment  $syncShipment
+     * @param  bool $displayNotifications
+     * @return bool
      */
     public function sync($syncShipment, $displayNotifications = false)
     {
@@ -184,8 +184,7 @@ class Shipment
                 ->setSyncedAt($this->_date->gmtDate())
                 ->save();
 
-        }
-        catch (Exception $e) {
+        } catch (Exception $e) {
             $this->_logger->addError('Shipment Sync Request Failed - ' . $e->getMessage());
 
             // Fail the sync item if it's breached the max attempts
@@ -207,11 +206,12 @@ class Shipment
 
     /**
      * Create shipment record
-     * @param  Order $order
-     * @param  array $items
-     * @param  string $courierName
-     * @param  string $trackingNumber
+     * @param Order $order
+     * @param array $items
+     * @param string $courierName
+     * @param string $trackingNumber
      * @return Shipment
+     * @throws Exception
      */
     protected function _createShipment($order, $items, $courierName, $trackingNumber)
     {

--- a/Model/Api/Shipment.php
+++ b/Model/Api/Shipment.php
@@ -20,10 +20,10 @@ use Exception;
 use Magento\Framework\App\Area as AppArea;
 use Shippit\Shipping\Model\Sync\Shipment as SyncShipment;
 
-class Shipment extends \Magento\Framework\Model\AbstractModel
+class Shipment
 {
     /**
-     * @var \Shippit\Shipping\Helper\Sync\Shipment
+     * @var \Shippit\Shipping\Helper\Sync\Shipping
      */
     protected $_helper;
 
@@ -88,12 +88,7 @@ class Shipment extends \Magento\Framework\Model\AbstractModel
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Magento\Store\Model\StoreManagerInterface $storeManagerInterface,
-        \Magento\Store\Model\App\Emulation $appEmulation,
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Registry $registry,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = []
+        \Magento\Store\Model\App\Emulation $appEmulation
     ) {
         $this->_helper = $helper;
         $this->_requestShipmentInterfaceFactory = $requestShipmentInterfaceFactory;
@@ -105,8 +100,6 @@ class Shipment extends \Magento\Framework\Model\AbstractModel
         $this->_storeManagerInterface = $storeManagerInterface;
         $this->_appEmulation = $appEmulation;
         $this->_transactionFactory = $transactionFactory;
-
-        parent::__construct($context, $registry, $resource, $resourceCollection, $data);
     }
 
     public function run()


### PR DESCRIPTION
Fixes #16 and also cleans up some of the other code with API Order and Shipment classes.

Removes `Magento\Framework\Model\AbstractModel` as parent of both classes, as it is unnecessary, and also causes issues with latest core changes.